### PR TITLE
Adapt Serilog InfluxDb sink to support Syslog format and fix 400 errors with invalid characters 

### DIFF
--- a/Serilog.Sinks.InfluxDB/Serilog.Sinks.InfluxDB.csproj
+++ b/Serilog.Sinks.InfluxDB/Serilog.Sinks.InfluxDB.csproj
@@ -1,14 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>InfluxDB sink for Serilog with .NET standard 2.0.</Description>
-    <Authors>Thiago Barradas;rifatx;iss0</Authors>
+    <Description>InfluxDB sink for Serilog with .NET standard 2.0 using syslog format for Influx1.X</Description>
+    <Authors>Steven JABBOUR</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageId>Serilog.Sinks.InfluxDB.Standard</PackageId>
+    <PackageId>Serilog.Sinks.InfluxDB.Syslog</PackageId>
     <PackageTags>serilog;logging;semantic;structured;influxdb;netcore;netcore2;netstandard2;netstandard2.0</PackageTags>
     <PackageIconUrl>http://serilog.net/images/serilog-sink-nuget.png</PackageIconUrl>
-    <PackageProjectUrl>https://github.com/ThiagoBarradas/serilog-sinks-influxdb</PackageProjectUrl>
-    <Product>Serilog.Sinks.InfluxDB.Standard</Product>
+    <PackageProjectUrl>https://github.com/pada57/serilog-sinks-influxdb</PackageProjectUrl>
+    <Product>Serilog.Sinks.InfluxDB.Syslog</Product>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBSink.cs
+++ b/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBSink.cs
@@ -128,16 +128,8 @@ namespace Serilog.Sinks.InfluxDB
                 messageTemplate.Text.Contains("HangFire:  - , Recurring job") ?
                     messageTemplate.Text.Split(new[] { ";Job:{" }, StringSplitOptions.RemoveEmptyEntries)?[0]
                     : HttpUtility.JavaScriptStringEncode(messageTemplate.Text)
-                // JsonConvert.ToString(messageTemplate.Text)
-                //.Replace("{", "\\{")
-                //.Replace("}", "\\}")
                 : string.Empty;
-            return new MessageTemplate(message, new[] { messageTemplate.Tokens.FirstOrDefault() });
-                //messageTemplate?.Text?.Replace("\n","")
-                //.Replace("\r", "")
-                //.Replace("\t", "")
-                //.Replace("\"", "\\\"")
-                //?? string.Empty;
+            return new MessageTemplate(message, new[] { messageTemplate.Tokens.FirstOrDefault() });                
         }
 
         /// <summary>

--- a/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/SyslogSeverity.cs
+++ b/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/SyslogSeverity.cs
@@ -1,0 +1,38 @@
+﻿using Serilog.Events;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Serilog.Sinks.InfluxDB.Sinks.InfluxDB
+{
+    public enum SyslogSeverity
+    {
+        emerg,
+        alert,
+        crit,
+        err,
+        warning,
+        notice,
+        info,
+        debug
+    }
+
+    public static class SyslogExtensions
+    {
+        public static SyslogSeverity ToSeverity(this LogEventLevel logEventLevel)
+        {
+            switch(logEventLevel)
+            {
+                case LogEventLevel.Error: return SyslogSeverity.err;
+                case LogEventLevel.Information: return SyslogSeverity.info;
+                case LogEventLevel.Warning: return SyslogSeverity.warning;
+                case LogEventLevel.Verbose: return SyslogSeverity.debug;
+                case LogEventLevel.Debug: return SyslogSeverity.debug;
+                case LogEventLevel.Fatal: return SyslogSeverity.emerg;
+                default:
+                    return SyslogSeverity.info;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adapt original sink to support Syslog format and being able to use influxdb log viewer
Also fix errors concerning all characters with are invalid on JSON payload to influx db API
* Errors like :
020-08-13T12:18:14.4004556Z Exception while emitting periodic batch from Serilog.Sinks.InfluxDB.InfluxDBSink: InfluxData.Net.Common.Infrastructure.InfluxDataApiException: InfluxData API responded with status code=BadRequest, response={"error":"partial write: unable to parse ',level=Information,messageTemplate=HangFire:\\ \\ -\\ \\,\\ Using\\ the\\ following\\ options\\ for\\ :\r': missing fields\nunable to parse '\\ \\ \\ \\ Worker\\ count:\\ 20\r': missing fields\nunable to parse '\\ \\ \\ \\ Listening\\ queues:\\ 'default'\r': missing fields\nunable to parse '\\ \\ \\ \\ Shutdown\\ timeout:\\ 00:00:15\r': missing fields dropped=0"}
