### PR TITLE
Change to use Uri instead of address and port which is more flexible

### DIFF
--- a/Serilog.Sinks.InfluxDB/LoggerConfigurationInfluxDBExtensions.cs
+++ b/Serilog.Sinks.InfluxDB/LoggerConfigurationInfluxDBExtensions.cs
@@ -74,6 +74,8 @@ namespace Serilog
             if (connectionInfo == null) throw new ArgumentNullException(nameof(connectionInfo));
             if (connectionInfo.Uri == null) throw new ArgumentNullException(nameof(connectionInfo.Uri));
             if (connectionInfo.DbName == null) throw new ArgumentNullException(nameof(connectionInfo.DbName));
+            if (connectionInfo.Username == null) connectionInfo.Username = string.Empty;
+            if (connectionInfo.Password == null) connectionInfo.Password = string.Empty;
 
             var defaultedPeriod = period ?? InfluxDBSink.DefaultPeriod;
 

--- a/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBConnectionInfo.cs
+++ b/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBConnectionInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 
 namespace Serilog.Sinks.InfluxDB
 {
@@ -12,21 +13,13 @@ namespace Serilog.Sinks.InfluxDB
         /// </summary>
         public InfluxDBConnectionInfo()
         {
-            Port = InfluxDBDefaults.DefaultPort;
             DbName = InfluxDBDefaults.DefaultDbName;
         }
 
         /// <summary>
-        /// Address of InfluxDB instance.
+        /// Uri to influx db instance.
         /// </summary>
-        public string Address { get; set; }
-
-        /// <summary>
-        /// Gets or sets the port used for the connection.
-        /// Default value is 8086.
-        /// </summary>
-        [DefaultValue(InfluxDBDefaults.DefaultPort)]
-        public int Port { get; set; }
+        public Uri Uri { get; set; }
 
         /// <summary>
         /// Gets or sets the database name in InfluxDB.

--- a/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBSink.cs
+++ b/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBSink.cs
@@ -104,7 +104,7 @@ namespace Serilog.Sinks.InfluxDB
         private InfluxDbClient CreateInfluxDbClient()
         {
             return new InfluxDbClient(
-                $"{_connectionInfo.Address}:{_connectionInfo.Port}",
+                _connectionInfo.Uri.AbsolutePath,
                 _connectionInfo.Username,
                 _connectionInfo.Password,
                 InfluxDbVersion.Latest);

--- a/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBSink.cs
+++ b/Serilog.Sinks.InfluxDB/Sinks/InfluxDB/InfluxDBSink.cs
@@ -104,7 +104,7 @@ namespace Serilog.Sinks.InfluxDB
         private InfluxDbClient CreateInfluxDbClient()
         {
             return new InfluxDbClient(
-                _connectionInfo.Uri.AbsolutePath,
+                _connectionInfo.Uri.ToString(),
                 _connectionInfo.Username,
                 _connectionInfo.Password,
                 InfluxDbVersion.Latest);


### PR DESCRIPTION
Change original Address and port parameters to use Uri in order to be more flexible for end users. Adapted extension methods